### PR TITLE
Fix race condition resulting in hung Acquire()

### DIFF
--- a/semaphore.go
+++ b/semaphore.go
@@ -111,6 +111,12 @@ func (s *semaphore) Acquire(ctx context.Context, n int) error {
 			broadcastCh := s.broadcastCh
 			s.lock.RUnlock()
 
+			// ensure that the state is the same as when we first checked; this
+			// ensures that the broadcastCh will eventually be closed by a Release.
+			if atomic.LoadUint64(&s.state) != state {
+				continue
+			}
+
 			select {
 			// check if context is done
 			case <-ctxDoneCh:


### PR DESCRIPTION
We detected a race condition that can cause a call to `Acquire()` to
hang indefinitely waiting on the wrong broadcast channel. The condition
occured like this:

1. T1 calls `Acquire()` and discovers the semaphore is full.
2. T2 calls `Release()` and decrements the semaphore.
3. T2 swaps the broadcast channel for a new broadcast channel, and closes
the old broadcast channel.
4. T1 grabs the broadcast channel, which is the new broadcast channel which
will not be signalled.

This condition is not permanent; the blocked thread will become
unblocked as soon as the semaphore fills up again, and a Release()
broadcasts on this channel. However, we were running into situations
where relatiely rare events could cause very long hangs due to this
condition.

Commit adds a test case which reproduces this situation quite
readily; as a race condition it does not reproduce 100% of the time, but
it reproduces very rapidly under stress, at least 30% of the time.

Commit also adds a fix; in `Acquire()`, after grabbing the old broadcast
channel the thread checks that the state has not changed (or at least,
that the semaphore is still full); this ensures that the broadcast
channel that was taken will eventually be signalled by a currently
active process.